### PR TITLE
Add continuous Pomodoro timer and improve leaderboard sorting

### DIFF
--- a/app/api/guardians/route.ts
+++ b/app/api/guardians/route.ts
@@ -8,7 +8,7 @@ export async function GET() {
     const { data: guardians, error } = await supabase
       .from("guardians")
       .select("*")
-      .order("achieved_at", { ascending: true })
+      .order("flower_count", { ascending: false })
 
     if (error) {
       console.error("Error fetching guardians:", error)

--- a/app/api/streamelements-token/route.ts
+++ b/app/api/streamelements-token/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from "next/server"
+
+export async function GET() {
+  const token = process.env.STREAMELEMENTS_JWT_TOKEN
+  if (!token) {
+    return NextResponse.json({ error: "Token not configured" }, { status: 500 })
+  }
+  return NextResponse.json({ token })
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -244,11 +244,8 @@ export default function DJRandomizer() {
 
     const handleHideAnyTimer = () => {
       // Use functional updates to avoid stale closures
+      // Work timer is independent - only !hideworktimer affects it
       setShowDarkTimer((prev) => {
-        if (prev) return false
-        return prev
-      })
-      setShowWorkTimer((prev) => {
         if (prev) return false
         return prev
       })
@@ -459,9 +456,8 @@ export default function DJRandomizer() {
   const handleSpin = (username: string) => {
     if (isSpinning) return
 
-    // Hide timers and celebrations but keep garden visible
+    // Hide timers and celebrations but keep garden and work timer visible
     if (showDarkTimer) setShowDarkTimer(false)
-    if (showWorkTimer) setShowWorkTimer(false)
     if (showSocialTimer) setShowSocialTimer(false)
     if (showFlowerShop) setShowFlowerShop(false)
     if (showFlowerCelebration) setShowFlowerCelebration(false)
@@ -493,9 +489,8 @@ export default function DJRandomizer() {
       setShowDarkTimer(true)
     } else if (socialTimerConnected) {
       setShowSocialTimer(true)
-    } else if (workTimerConnected) {
-      setShowWorkTimer(true)
     }
+    // Work timer is never hidden/restored by other timers - it stays independent
   }
 
   const addTrick = (name: string, definition: string) => {

--- a/components/streamelements-service.tsx
+++ b/components/streamelements-service.tsx
@@ -40,8 +40,22 @@ export function useStreamElements() {
   const wsRef = useRef<WebSocket | null>(null)
 
   useEffect(() => {
-    const JWT_TOKEN =
-      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJjaXRhZGVsIiwiZXhwIjoxNzcxNjEyOTk1LCJqdGkiOiI4MGZiMjUxZi1lNDNhLTRjMTMtOGFkMS04MzRmNjBmZWMzODMiLCJjaGFubmVsIjoiNjRhZTk3ZWNjOTBjNWJjMjZiMGMwZjk3Iiwicm9sZSI6Im93bmVyIiwiYXV0aFRva2VuIjoiY1JwbjJhdmVlMjVMSFZHMUlUcVdLOXViVG1KYTNtQmw3ZFBSZTR3UkFGRDBRX3Q0IiwidXNlciI6IjY0YWU5N2VjYzkwYzViYzI2YjBjMGY5NiIsInVzZXJfaWQiOiJiNjM0NmM2ZS0yZjA2LTQwNmEtOTQ0ZC04NzQ5YjM1ODZhYTYiLCJ1c2VyX3JvbGUiOiJjcmVhdG9yIiwicHJvdmlkZXIiOiJ0d2l0Y2giLCJwcm92aWRlcl9pZCI6Ijg1NzczMTUxNyIsImNoYW5uZWxfaWQiOiI3N2QyYTU2NS1hM2JhLTRkNzktYjg5ZS05ODEzZTQyMmViNDYiLCJjcmVhdG9yX2lkIjoiODc2YjIxOGItMThmNi00YzkzLTg5MTEtYTc3MTBjYTc0YjdiIn0.tk56AEzeBCVFApK8WRN2YWSxmki-GHXFc6nk1TbaVfI"
+    let jwtToken = ""
+
+    const fetchTokenAndConnect = async () => {
+      try {
+        const res = await fetch("/api/streamelements-token")
+        const data = await res.json()
+        if (data.token) {
+          jwtToken = data.token
+          connectToStreamElements()
+        } else {
+          console.log("[v0] Failed to fetch StreamElements token")
+        }
+      } catch (err) {
+        console.log("[v0] Error fetching StreamElements token:", err)
+      }
+    }
 
     const connectToStreamElements = () => {
       try {
@@ -57,7 +71,7 @@ export function useStreamElements() {
             JSON.stringify({
               type: "authenticate",
               data: {
-                token: JWT_TOKEN,
+                token: jwtToken,
                 token_type: "jwt",
               },
             }),
@@ -71,7 +85,7 @@ export function useStreamElements() {
               data: {
                 topic: "channel.activities",
                 room: "64ae97ecc90c5bc26b0c0f97",
-                token: JWT_TOKEN,
+                token: jwtToken,
                 token_type: "jwt",
               },
             }),
@@ -161,8 +175,8 @@ export function useStreamElements() {
       }
     }
 
-    connectToStreamElements()
-
+    fetchTokenAndConnect()
+  
     return () => {
       if (wsRef.current) {
         wsRef.current.close()


### PR DESCRIPTION
- Added a continuous Pomodoro timer featuring celebration effects and Twitch-inspired styling.
- Fixed work timer settings to ensure isolation and prevent interference from other active timers.
- Updated the Guardians list to sort entries by flower count.
- Improved WebSocket connection reliability by moving JWT token retrieval to a server-side endpoint.

[v0 Session](https://v0.app/chat/30SleB7HZWj)