### PR TITLE
Enhance Pomodoro timer with audio alerts and continuous mode

### DIFF
--- a/components/chat-integration.tsx
+++ b/components/chat-integration.tsx
@@ -318,6 +318,10 @@ export function ChatIntegration({ onSpin, onHide, onConnectionChange }: ChatInte
           console.log("Hide credits command detected")
           window.dispatchEvent(new CustomEvent("hideCredits", { detail: { username } }))
           addRecentCommand(`${command} by ${username}`)
+        } else if (command === "!loontest" && (isMod || isBroadcaster)) {
+          console.log("Loon test command detected")
+          window.dispatchEvent(new CustomEvent("loonTest", { detail: { username } }))
+          addRecentCommand(`${command} by ${username}`)
         } else if (command === "!testflowerboard" && (isMod || isBroadcaster || isVip)) {
           console.log("Test flowerboard command detected")
           window.dispatchEvent(

--- a/components/work-timer.tsx
+++ b/components/work-timer.tsx
@@ -87,12 +87,23 @@ export function WorkTimer({ isVisible, onConnectionChange, onHide }: WorkTimerPr
   // Keep ref in sync
   isVisibleRef.current = isVisible
 
-  // Initialize audio element once
+  // Initialize audio element once and listen for !loontest command
   useEffect(() => {
     const audio = new Audio("/sounds/loon_sample.wav")
     audio.volume = 0.3
     audioRef.current = audio
+
+    const handleLoonTest = () => {
+      if (audioRef.current) {
+        audioRef.current.currentTime = 0
+        audioRef.current.play().catch(() => {})
+      }
+    }
+
+    window.addEventListener("loonTest", handleLoonTest)
+
     return () => {
+      window.removeEventListener("loonTest", handleLoonTest)
       audio.pause()
       audio.src = ""
     }

--- a/public/sounds/loon_sample.wav
+++ b/public/sounds/loon_sample.wav
@@ -1,0 +1,1 @@
+Non-image binary files cannot be read directly. It is available at the following URL: https://blobs.vusercontent.net/blob/loon_sample-nw77zEoLG6bg1vstT4j4x5ddeW3015.wav


### PR DESCRIPTION
- Enabled continuous timer mode to automatically transition between work and break sessions
- Improved leaderboard sorting logic to ensure more accurate rankings
- Added loon sound effects at 30% volume to signal phase transitions
- Introduced a `!loontest` command for broadcasters and moderators to manually trigger audio tests

[v0 Session](https://v0.app/chat/30SleB7HZWj)