### PR TITLE
Enhance Pomodoro timer and remove audio alerts

### DIFF
--- a/components/chat-integration.tsx
+++ b/components/chat-integration.tsx
@@ -318,10 +318,6 @@ export function ChatIntegration({ onSpin, onHide, onConnectionChange }: ChatInte
           console.log("Hide credits command detected")
           window.dispatchEvent(new CustomEvent("hideCredits", { detail: { username } }))
           addRecentCommand(`${command} by ${username}`)
-        } else if (command === "!loontest" && (isMod || isBroadcaster)) {
-          console.log("Loon test command detected")
-          window.dispatchEvent(new CustomEvent("loonTest", { detail: { username } }))
-          addRecentCommand(`${command} by ${username}`)
         } else if (command === "!testflowerboard" && (isMod || isBroadcaster || isVip)) {
           console.log("Test flowerboard command detected")
           window.dispatchEvent(

--- a/public/sounds/loon_sample.wav
+++ b/public/sounds/loon_sample.wav
@@ -1,1 +1,0 @@
-Non-image binary files cannot be read directly. It is available at the following URL: https://blobs.vusercontent.net/blob/loon_sample-nw77zEoLG6bg1vstT4j4x5ddeW3015.wav

--- a/public/sounds/loon_sample.wav
+++ b/public/sounds/loon_sample.wav
@@ -1,0 +1,1 @@
+Non-image binary files cannot be read directly. It is available at the following URL: https://blobs.vusercontent.net/blob/loon_sample-nw77zEoLG6bg1vstT4j4x5ddeW3015.wav


### PR DESCRIPTION
- Added continuous mode functionality to the Pomodoro timer.
- Removed audio alert features and the `loontest` command from chat integration.
- Silenced work timer notifications to reduce session interruptions.

[v0 Session](https://v0.app/chat/30SleB7HZWj)